### PR TITLE
Fix FWC issue

### DIFF
--- a/lib/solver/constraints/propagators/all_different_fwc.ex
+++ b/lib/solver/constraints/propagators/all_different_fwc.ex
@@ -12,7 +12,7 @@ defmodule CPSolver.Propagator.AllDifferent.FWC do
   end
 
   defp initial_state(args) do
-    %{unfixed_vars: Map.new(args, fn v -> {v.id, v} end)}
+    %{unfixed_vars: Map.new(args, fn v -> {id(v), v} end)}
   end
 
   @impl true
@@ -58,15 +58,15 @@ defmodule CPSolver.Propagator.AllDifferent.FWC do
 
     Enum.each(
       variables,
-      fn
-        var when var.id == variable.id ->
+      fn var ->
+        if id(var) == id(variable) do
           :ok
-
-        var ->
+        else
           case remove(var, value) do
             :fixed -> remove_variable(var, variables)
             _ -> :ok
           end
+        end
       end
     )
   end

--- a/lib/solver/core/solver.ex
+++ b/lib/solver/core/solver.ex
@@ -8,6 +8,7 @@ defmodule CPSolver do
   alias CPSolver.Constraint
   alias CPSolver.Solution
   alias CPSolver.Propagator
+  alias CPSolver.Variable.Interface
 
   alias CPSolver.Shared
 
@@ -38,7 +39,10 @@ defmodule CPSolver do
      shared_data
      |> Map.put(:objective, strip_objective(Map.get(model, :objective)))
      |> Map.put(:solver_pid, solver_pid)
-     |> Map.put(:variable_names, Enum.map(model.variables, & &1.name))}
+     |> Map.put(
+       :variable_names,
+       Enum.map(model.variables, fn var -> Interface.variable(var).name end)
+     )}
   end
 
   defp strip_objective(nil) do
@@ -258,7 +262,7 @@ defmodule CPSolver do
     indexed_variables =
       variables
       |> Enum.with_index(1)
-      |> Map.new(fn {v, idx} -> {v.id, Map.put(v, :index, idx)} end)
+      |> Map.new(fn {v, idx} -> {Interface.id(v), Map.put(Interface.variable(v), :index, idx)} end)
 
     bound_propagators =
       Enum.reduce(constraints, [], fn constraint, acc ->

--- a/lib/solver/domain/default_domain.ex
+++ b/lib/solver/domain/default_domain.ex
@@ -67,14 +67,14 @@ defmodule CPSolver.DefaultDomain do
           | {Common.domain_change(), :ordsets.set(number())}
 
   def removeAbove(domain, value) do
-    :ordsets.filter(fn v -> v <= value end, domain)
+    Enum.take_while(domain, fn v -> v <= value end)
     |> post_remove(domain, :max_change)
   end
 
   @spec removeBelow(:ordsets.set(number()), number()) ::
           :fail | :no_change | {Common.domain_change(), :ordsets.set(number())}
   def removeBelow(domain, value) do
-    :ordsets.filter(fn v -> v >= value end, domain)
+    Enum.drop_while(domain, fn v -> v < value end)
     |> post_remove(domain, :min_change)
   end
 

--- a/lib/solver/model/model.ex
+++ b/lib/solver/model/model.ex
@@ -1,6 +1,7 @@
 defmodule CPSolver.Model do
   alias CPSolver.Constraint
   alias CPSolver.Variable
+  alias CPSolver.Variable.Interface
   alias CPSolver.Objective
 
   defstruct [:name, :variables, :constraints, :objective, :extra, :id]
@@ -25,7 +26,7 @@ defmodule CPSolver.Model do
   end
 
   def model_variables(variables, constraints) do
-    variable_map = Map.new(variables, fn v -> {v.id, v} end)
+    variable_map = Map.new(variables, fn v -> {Interface.id(v), Interface.variable(v)} end)
 
     ## Additional variables may come from constraint definitions
     ## (example: LessOrEqual constraint, where the second argument is a constant value).

--- a/lib/solver/solution/solution.ex
+++ b/lib/solver/solution/solution.ex
@@ -1,4 +1,6 @@
 defmodule CPSolver.Solution do
+  alias CPSolver.Variable.Interface
+
   @callback handle(solution :: %{reference() => number() | boolean()}) :: any()
   def default_handler() do
     CPSolver.Solution.DefaultHandler
@@ -27,7 +29,7 @@ defmodule CPSolver.Solution do
       Enum.find_index(
         variables,
         fn var ->
-          var.name == var_name
+          Interface.variable(var).name == var_name
         end
       )
     end)

--- a/lib/solver/space/propagation.ex
+++ b/lib/solver/space/propagation.ex
@@ -48,9 +48,13 @@ defmodule CPSolver.Space.Propagation do
   def propagate(propagators, graph, store) when is_map(propagators) do
     propagators
     |> reorder()
-    |> Task.async_stream(fn {p_id, p} ->
-      {p_id, Propagator.filter(p, store: store)}
-    end)
+    |> Task.async_stream(
+      fn {p_id, p} ->
+        {p_id, Propagator.filter(p, store: store)}
+      end,
+      ## TODO: make it an option
+      max_concurrency: 1
+    )
     |> Enum.reduce_while({MapSet.new(), graph}, fn {:ok, {p_id, res}}, {scheduled, g} = _acc ->
       case res do
         {:fail, _var} ->

--- a/lib/solver/store/store.ex
+++ b/lib/solver/store/store.ex
@@ -6,6 +6,7 @@ defmodule CPSolver.ConstraintStore do
   """
   #################
   alias CPSolver.{Common, Variable}
+  alias CPSolver.Variable.Interface
   alias CPSolver.DefaultDomain, as: Domain
 
   require Logger
@@ -89,6 +90,7 @@ defmodule CPSolver.ConstraintStore do
   def create_store(variables, opts \\ [])
 
   def create_store(variables, opts) do
+    variables = Enum.map(variables, &Interface.variable/1)
     opts = Keyword.merge(default_store_opts(), opts)
     space = Keyword.get(opts, :space)
     store_impl = Keyword.get(opts, :store_impl)

--- a/test/propagators/all_different_fwc_test.exs
+++ b/test/propagators/all_different_fwc_test.exs
@@ -52,18 +52,25 @@ defmodule CPSolverTest.Propagator.AllDifferent.FWC do
     test "cascading filtering" do
       ## x1 is fixed, so the filtering removes 1 from all other variables.
       ## This makes x2 fixed, which in turn triggers a removal of 2 from x3 to x5 etc.
-      ## Eventually all variables become fixed
+      ## Eventually all variables become fixed, and this will take a single filtering call.
       ##
       x =
-        Enum.map([{"x1", 1}, {"x2", 1..2}, {"x3", 1..3}, {"x4", 1..4}, {"x5", 1..5}], fn {name, d} ->
+        Enum.map([{"x2", 1..2}, {"x1", 1}, {"x3", 1..3}, {"x4", 1..4}, {"x5", 1..5}], fn {name, d} ->
           Variable.new(d, name: name)
         end)
 
       {:ok, x_vars, _store} = ConstraintStore.create_store(x)
 
       fwc_propagator = FWC.new(x_vars)
-      _filtering_results = Propagator.filter(fwc_propagator)
+      %{changes: changes} = Propagator.filter(fwc_propagator)
 
+      ## x1 was already fixed; the filtering fixed the rest
+      assert map_size(changes) == length(x_vars) - 1
+      assert Enum.all?(Map.values(changes), fn change -> change == :fixed end)
+      assert Enum.all?(x_vars, &Interface.fixed?/1)
+
+      ## Consequent filtering does not result in more changes and/or failures
+      %{changes: nil} = Propagator.filter(fwc_propagator)
       assert Enum.all?(x_vars, &Interface.fixed?/1)
     end
   end


### PR DESCRIPTION
Race condition when using FWC - propagators fix variables simultaneously using their internal state; this leads to underreporting of the changes and consequently, to erroneous scheduling. 
Something to revisit. The (temporary?) fix is to run propagation synchronously.
The performance is better (!), but will it hold for bigger problems?
TODO: enable :max_concurrency as an option for Space.Propagator.propagate/_