### PR TITLE
AllDifferent FWC implementation that applies `:fixed` events 

### DIFF
--- a/lib/solver/constraints/propagators/all_different_fwc.ex
+++ b/lib/solver/constraints/propagators/all_different_fwc.ex
@@ -6,30 +6,25 @@ defmodule CPSolver.Propagator.AllDifferent.FWC do
   """
 
   @impl true
-  def reset(_args, _state) do
-    nil
+  def reset(args, nil) do
+    {initial_unfixed_vars, initial_fixed_values} = initial_reduction(args)
+    %{unfixed_vars: initial_unfixed_vars, fixed_values: initial_fixed_values}
   end
 
-  # def reset(args, %{unfixed_vars: unfixed, fixed_values: fixed} = _state) do
-  #   ## Refresh the state:
-  #   ## find and apply new fixed values
-  #   Enum.reduce(unfixed, {unfixed, MapSet.new(), fixed}, fn {_ref, idx}, {unfixed_acc, fixed_acc, total_fixed_acc} ->
-  #     var = get_variable(args, idx)
-  #     if fixed?(var) do
-  #       new_value = min(var)
-  #       {Map.delete(unfixed_acc, idx),
-  #         add_fixed_value(fixed_acc, new_value),
-  #         add_fixed_value(total_fixed_acc, new_value),
-  #       }
-  #     else
-  #       {unfixed_acc, fixed_acc, total_fixed_acc}
-  #     end
-  #   end)
-  #   |> then(fn {new_unfixed, new_fixed, total_fixed} ->
-  #     #{final_unfixed, final_fixed} = fwc(args, new_unfixed, new_fixed, total_fixed)
-  #     %{unfixed_vars: new_unfixed, fixed_values: MapSet.union(fixed, new_fixed)}
-  #   end)
-  # end
+  def reset(args, %{fixed_values: fixed_values, unfixed_vars: unfixed_vars} = _state) do
+
+    {unfixed_vars, delta,  total_fixed} = Enum.reduce(unfixed_vars, {unfixed_vars, MapSet.new(), fixed_values}, fn {ref, idx}, {unfixed_acc, delta_acc, total_fixed_acc} = acc ->
+      case get_value(args, idx) do
+        nil -> acc
+        value ->
+      {Map.delete(unfixed_acc, ref), add_fixed_value(delta_acc, value), add_fixed_value(total_fixed_acc, value)}
+        end
+    end)
+
+    {final_unfixed_vars, final_fixed_values} = fwc(args, unfixed_vars, delta, total_fixed)
+    %{unfixed_vars: final_unfixed_vars, fixed_values: final_fixed_values}
+
+  end
 
   defp initial_reduction(args) do
     Enum.reduce(
@@ -157,11 +152,21 @@ defmodule CPSolver.Propagator.AllDifferent.FWC do
       MapSet.put(fixed_values, value)
   end
 
+  defp get_value(_variables, nil) do
+    nil
+  end
+
   defp get_value(variables, idx) do
-    (idx && get_variable(variables, idx) |> min()) || nil
+    case get_variable(variables, idx) do
+      nil ->
+        nil
+      var -> fixed?(var) && min(var) || nil
+    end
   end
 
   defp get_variable(variables, idx) do
     (idx && Enum.at(variables, idx)) || nil
   end
+
+
 end

--- a/lib/solver/core/propagator/propagator.ex
+++ b/lib/solver/core/propagator/propagator.ex
@@ -88,12 +88,12 @@ defmodule CPSolver.Propagator do
     ## The propagation may reshedule the filtering and pass the changes that woke
     ## the propagator.
     incoming_changes = Keyword.get(opts, :changes) || %{}
-    ## If the filtering is called with no incoming changes
-    ## is when the propagator is called in the first round of propagation.
-    ## We reset the state of propagator in this case.
+    ## We will reset the state if required.
+    ## Reset will be forced when the space starts propagation.
+    reset? = Keyword.get(opts, :reset?, false)
 
     try do
-      state = mod.reset(args, state)
+      state = reset? && mod.reset(args, state) || state
       mod.filter(args, state, incoming_changes)
     catch
       :fail ->

--- a/lib/solver/core/propagator/propagator.ex
+++ b/lib/solver/core/propagator/propagator.ex
@@ -93,8 +93,8 @@ defmodule CPSolver.Propagator do
     ## We reset the state of propagator in this case.
 
     try do
-      propagator_state = mod.reset(args, state)
-      mod.filter(args, propagator_state, incoming_changes)
+      state = mod.reset(args, state)
+      mod.filter(args, state, incoming_changes)
     catch
       :fail ->
         :fail

--- a/lib/solver/space/propagation.ex
+++ b/lib/solver/space/propagation.ex
@@ -214,7 +214,15 @@ defmodule CPSolver.Space.Propagation do
     :domain_change
   end
 
+  defp maybe_update_domain_change(_current_change, :domain_change) do
+    :domain_change
+  end
+
   defp maybe_update_domain_change(:min_change, :max_change) do
+    :bound_change
+  end
+
+  defp maybe_update_domain_change(:max_change, :min_change) do
     :bound_change
   end
 

--- a/lib/solver/space/space.ex
+++ b/lib/solver/space/space.ex
@@ -26,7 +26,7 @@ defmodule CPSolver.Space do
       store_impl: CPSolver.ConstraintStore.default_store(),
       solution_handler: Solution.default_handler(),
       search: Search.default_strategy(),
-      max_space_threads: 8,
+      max_space_threads: :erlang.system_info(:logical_processors),
       postpone: false,
       distributed: false
     ]

--- a/test/constraints/all_different_fwc_test.exs
+++ b/test/constraints/all_different_fwc_test.exs
@@ -14,12 +14,11 @@ defmodule CPSolverTest.Constraint.AllDifferent.FWC do
 
       model = Model.new(variables, [Constraint.new(AllDifferentFWC, variables)])
 
-      {:ok, solver} = CPSolver.solve(model)
+      {:ok, result} = CPSolver.solve_sync(model, timeout: 100)
 
-      Process.sleep(100)
-      assert CPSolver.statistics(solver).solution_count == 6
+      assert result.statistics.solution_count == 6
 
-      assert CPSolver.solutions(solver) |> Enum.sort() == [
+      assert result.solutions |> Enum.sort() == [
                [1, 2, 3],
                [1, 3, 2],
                [2, 1, 3],
@@ -27,6 +26,24 @@ defmodule CPSolverTest.Constraint.AllDifferent.FWC do
                [3, 1, 2],
                [3, 2, 1]
              ]
+    end
+
+    test "unsatisfiable (duplicates)" do
+      variables = Enum.map(1..3, fn _ -> IntVariable.new(1) end)
+      model = Model.new(variables, [Constraint.new(AllDifferentFWC, variables)])
+
+      {:ok, result} = CPSolver.solve_sync(model, timeout: 1000)
+
+      assert result.status == :unsatisfiable
+    end
+
+    test "unsatisfiable(pigeon hole)" do
+      variables = Enum.map(1..4, fn _ -> IntVariable.new(1..3) end)
+      model = Model.new(variables, [Constraint.new(AllDifferentFWC, variables)])
+
+      {:ok, result} = CPSolver.solve_sync(model, timeout: 100)
+
+      assert result.status == :unsatisfiable
     end
 
     test "views in variable list" do

--- a/test/constraints/all_different_fwc_test.exs
+++ b/test/constraints/all_different_fwc_test.exs
@@ -8,6 +8,16 @@ defmodule CPSolverTest.Constraint.AllDifferent.FWC do
     alias CPSolver.Model
     import CPSolver.Variable.View.Factory
 
+    test "all fixed"  do
+      variables = Enum.map(1..5, fn i -> IntVariable.new(i) end)
+      model = Model.new(variables, [Constraint.new(AllDifferentFWC, variables)])
+      {:ok, result} = CPSolver.solve_sync(model, timeout: 100)
+
+      assert hd(result.solutions) == [1, 2, 3, 4, 5]
+      assert result.statistics.solution_count == 1
+
+    end
+
     test "produces all possible permutations" do
       domain = 1..3
       variables = Enum.map(1..3, fn _ -> IntVariable.new(domain) end)

--- a/test/solver/cpsolver_test.exs
+++ b/test/solver/cpsolver_test.exs
@@ -109,7 +109,6 @@ defmodule CpSolverTest do
       |> String.split("\n")
       |> Enum.map(fn binary -> :erlang.binary_to_term(binary) end)
 
-
     ## Make {ref, value} list off the solver solutions
     ## to be able to compare with the output of solutuon handler
     solver_solutions =

--- a/test/space/space_propagation_test.exs
+++ b/test/space/space_propagation_test.exs
@@ -71,13 +71,16 @@ defmodule CPSolverTest.SpacePropagation do
       Propagation.propagate(propagators, graph, store)
 
     assert Enum.all?(scheduled_propagators, fn p_id -> p_id in Map.keys(domain_changes) end)
-    refute Enum.any?(Map.values(domain_changes), fn change -> MapSet.size(change) == 0 end)
 
     assert Enum.all?(propagators, fn p ->
              propagator_domain_changes = Map.get(domain_changes, p.id)
              var_id_set = MapSet.new(Enum.map(p.args, fn v -> v.id end))
-             MapSet.subset?(Enum.map(propagator_domain_changes, fn {var_id, _change} -> var_id end) |> MapSet.new(),
-             var_id_set)
+
+             MapSet.subset?(
+               Enum.map(propagator_domain_changes, fn {var_id, _change} -> var_id end)
+               |> MapSet.new(),
+               var_id_set
+             )
            end)
 
     ## Propagators are not being rescheduled


### PR DESCRIPTION
The previous implementation of FWC had to go through the list of unfixed vars to detect the new fixed vars.
This one goes through (likely, shorter) list of fixed vars produced by  the propagation step.
